### PR TITLE
ハッシュタグの疑似サポート

### DIFF
--- a/public/js/default.js
+++ b/public/js/default.js
@@ -256,12 +256,16 @@ $(function(){
 	// automatic link plugin
 	$.fn.autoLink = function(config){
 		this.each(function(){
-			var re = /(https?|ftp):\/\/[\(\)%#!\/0-9a-zA-Z_$@.&+-,'"*=;?:~-]+/g;
+			var re = /((https?|ftp):\/\/[\(\)%#!\/0-9a-zA-Z_$@.&+-,'"*=;?:~-]+|#\S+)/g;
 			$(this).html(
 				$(this).html().replace(re, function(u){
 					try {
-						var url = $.url(u);
-						return '[<a href="'+u+'" target="_brank">'+url.attr('host')+'</a>]';
+						if (u.match(/^#/)) {
+							return '<a href="/search?q='+encodeURIComponent(u)+'">'+u+'</a>';
+						} else {
+							var url = $.url(u);
+							return '[<a href="'+u+'" target="_brank">'+url.attr('host')+'</a>]';
+						}
 					}catch(e){
 						return u;
 					}


### PR DESCRIPTION
ひとこと中の「#キーワード」という記述を、そのキーワード(#含む)で検索するURLへのリンクに変換するようにしてみました。twitterのハッシュタグとは違って全角の＃は対象にしてないです。キーワードに該当するのは空白文字以外すべて。
default.jsのautolinkの処理の際に同時に処理するので#を含むURLが貼られてる際に誤爆はしないようになっています。
