### PR TITLE
show filesize of MongoDB in Admin page

### DIFF
--- a/helpers/init.rb
+++ b/helpers/init.rb
@@ -72,3 +72,4 @@ end
 
 require_relative 'resource'
 require_relative 'picasa'
+require_relative 'stats'

--- a/helpers/stats.rb
+++ b/helpers/stats.rb
@@ -1,0 +1,19 @@
+# -*- coding: utf-8; -*-
+#
+# helpers/stats.rb : system statuses
+#
+# Copyright (C) 2014 by The wasam@s production
+# https://github.com/tdtds/massr
+#
+# Distributed under GPL
+#
+
+module Massr
+	class App < Sinatra::Base
+		helpers do
+			def stats(item)
+				MongoMapper.database.stats[item.to_s]
+			end
+		end
+	end
+end

--- a/views/admin.haml
+++ b/views/admin.haml
@@ -25,6 +25,11 @@
 									= member.name
 									%a.delete
 										%i.icon-trash{:title => _delete_user}
+						%h2<Stats
+						%p
+							fileSize: 
+							= stats(:fileSize).to_s.reverse.gsub(/\d\d\d/,',\\0').reverse.sub(/,$/, '')
+							bytes
 				.span3
 					!= haml :sidebar
 		!= haml :footer


### PR DESCRIPTION
気になるmongoのファイルサイズをadminページに表示するパッチ

![s](https://cloud.githubusercontent.com/assets/65746/4456830/2dfa036c-488f-11e4-9cc2-77049e372626.jpg)
