### PR TITLE
work around fix of fatal error in image_size_change by dirty cache

### DIFF
--- a/helpers/init.rb
+++ b/helpers/init.rb
@@ -68,7 +68,11 @@ module Massr
 			end
 
 			def image_size_change url,size,centering
-				uri = URI.parse(url)
+				begin
+					uri = URI.parse(url)
+				rescue URI::InvalidURIError
+					puts "Fatal error in image_size_change cause by dirty cache"
+				end
 
 				if (uri.host =~ /\A[0-9a-zA-Z]+\.googleusercontent\.com\z/)
 					pattern = /\/([whs][0-9]+|r(90|180|270)|-|c|p|o|d)+\//


### PR DESCRIPTION
検索でキャッシュが汚染されて500エラーになるヤツ、とりあえず例外を握りつぶしてメッセージだけ吐くようにしたワークアラウンドをあげておきます。根本解決は別途。

メッセージをPapertrailあたりで監視しておけば、走りながら対応できるかな?