### PR TITLE
特定のサービスのURLは展開して埋め込むようにした

### DIFF
--- a/assets/js/jquery.auto-link.js
+++ b/assets/js/jquery.auto-link.js
@@ -48,12 +48,8 @@ $(function(){
 								});
 							}
 							else if (u.match(/https?:\/\/www\.youtube\.com\/watch\?v=([0-9a-zA-Z_]+)/)) {
-								embed += '<iframe id="ytplayer" type="text/html" src="//www.youtube.com/embed/' +
-										RegExp.$1 + '" frameborder="0" />';
-							}
-							else if (u.match(/https?:\/\/www\.nicovideo\.jp\/watch\/([0-9a-z]+)/)) {
-								embed += '<iframe width="312" height="176" src="http://ext.nicovideo.jp/thumb/' + RegExp.$1 +
-										 '" scrolling="no" style="border:solid 1px #CCC;" frameborder="0">';
+								embed += '<div><iframe id="ytplayer" type="text/html" src="//www.youtube.com/embed/' +
+										RegExp.$1 + '" frameborder="0" /></div>';
 							}
 
 							return '[<a href="'+u+'" target="_blank">'+url.attr('host')+'</a>]';

--- a/assets/js/jquery.auto-link.js
+++ b/assets/js/jquery.auto-link.js
@@ -7,9 +7,28 @@
  */
 
 $(function(){
+	// load twitter widget
+	window.twttr = (function(d, s, id) {
+		var js, fjs = d.getElementsByTagName(s)[0],
+			t = window.twttr || {};
+		if (d.getElementById(id)) return t;
+		js = d.createElement(s);
+		js.id = id;
+		js.src = "https://platform.twitter.com/widgets.js";
+		fjs.parentNode.insertBefore(js, fjs);
+
+		t._e = [];
+		t.ready = function(f) {
+			t._e.push(f);
+		};
+
+		return t;
+	}(document, "script", "twitter-wjs"));
+
 	$.fn.autoLink = function(config){
 		this.each(function(){
 			var re = /((https?|ftp):\/\/[\(\)%#!\/0-9a-zA-Z_$@.&+-,'"*=;?:~-]+|^#[^#\s]+|\s#[^#\s]+)/g;
+			var embed = "";
 			$(this).html(
 				$(this).html().replace(re, function(u){
 					try {
@@ -20,12 +39,29 @@ $(function(){
 							return prefix + '<a href="/search?q='+encodeURIComponent(tag)+'">'+tag+'</a>';
 						} else {
 							var url = $.url(u);
+							if (u.match(/https?:\/\/twitter\.com\/.+\/status\/(\d+)$/)) {
+								// embed tweet
+								var tweet_id = RegExp.$1;
+								embed += '<div id="tw' + tweet_id + '"></div>';
+								twttr.ready(function() {
+									twttr.widgets.createTweet(tweet_id, $('#tw'+tweet_id).get(0),{cards:'hidden'});
+								});
+							}
+							else if (u.match(/https?:\/\/www\.youtube\.com\/watch\?v=([0-9a-zA-Z_]+)/)) {
+								embed += '<iframe id="ytplayer" type="text/html" src="//www.youtube.com/embed/' +
+										RegExp.$1 + '" frameborder="0" />';
+							}
+							else if (u.match(/https?:\/\/www\.nicovideo\.jp\/watch\/([0-9a-z]+)/)) {
+								embed += '<iframe width="312" height="176" src="http://ext.nicovideo.jp/thumb/' + RegExp.$1 +
+										 '" scrolling="no" style="border:solid 1px #CCC;" frameborder="0">';
+							}
+
 							return '[<a href="'+u+'" target="_blank">'+url.attr('host')+'</a>]';
 						}
 					}catch(e){
 						return u;
 					}
-				})
+				}) + embed
 			);
 		});
 		return this;


### PR DESCRIPTION
#99 の実装案。
twitter、Youtube、ニコ動のURLが貼られたら、auto linkだけでなく内容を埋め込むようにしてみました。

- twitterは公式のAPIを使用。`{ cards: 'hidden' }`の指定をやめると画像とかも表示されますが若干画面がうるさ過ぎる感じになります。
- Youtubeは公式のiframe埋め込みを使用。縦横を指定するともっと大きく表示できますが、埋め込み用としてはこんなものかと。
- ニコ動は外部プレイヤーがJSで動的にロードできない仕様&(UIが)ゴツいので、動画情報とサムネの埋め込みjsのほうを使いました

これら以外に例えば http://embed.ly/ を使うと汎用的にURLの埋め込みが出来ますが、OGPに対応してないとイマイチな感じでした。わさます調べでは今回埋め込みに対応したURL以外だとmassr自身のURLを貼るケースが結構多いので、自分自身の埋め込みに対応できると良いのかもしれません。