### PR TITLE
Enhance image usability

### DIFF
--- a/assets/js/massr.templates.js
+++ b/assets/js/massr.templates.js
@@ -35,7 +35,12 @@ $(function(){
 					).append(
 						$('<div>').addClass('statement-res').append(
 							$('<a>').attr('href', '/statement/'+s.res.id).
-								text('< ' + Massr.shrinkText(s.res.body)))
+								text('< ' + Massr.shrinkText(s.res.body)).each(function(){
+									if (s.res.stamp) {
+										$(this).append($('<img>').attr('src', $.fn.image_size_change(s.res.stamp,16,true)).
+										attr('alt', s.res.stamp).attr('title', s.res.stamp));
+									}
+								}))
 					);
 				}
 			}).append(

--- a/views/popup_photo.haml
+++ b/views/popup_photo.haml
@@ -7,7 +7,7 @@
 			%a.usestamp
 				%i.icon-ok-circle{:title => _use_stamp }
 	.image
-		%a{:href => "#{photo}"}
+		%a{:href => "#{photo}", :target => "_blank"}
 			%img{:src => "#{photo}" , :alt => "#{statement._id}" , :title => "#{statement._id}"}
 	- if detail
 		.statement{:id => "st-#{statement._id}"}
@@ -15,7 +15,7 @@
 			.statement-icon
 				%a{:href => "/user/#{statement.user.massr_id}"}
 					%img.massr-icon{:src => get_icon_url(statement.user)}
-		
+
 			%div{:class => "#{session[:user_id] == statement.user._id ? "statement-body-me statement-body" : "statement-body"}"}
 				/ 発言本文
 				.statement-message<

--- a/views/popup_photo.haml
+++ b/views/popup_photo.haml
@@ -7,7 +7,8 @@
 			%a.usestamp
 				%i.icon-ok-circle{:title => _use_stamp }
 	.image
-		%img{:src => "#{photo}" , :alt => "#{statement._id}" , :title => "#{statement._id}"}
+		%a{:href => "#{photo}"}
+			%img{:src => "#{photo}" , :alt => "#{statement._id}" , :title => "#{statement._id}"}
 	- if detail
 		.statement{:id => "st-#{statement._id}"}
 			/ アイコン

--- a/views/statement.haml
+++ b/views/statement.haml
@@ -14,6 +14,8 @@
 			.statement-res
 				%a{:href => "/statement/#{statement.res._id}"}
 					&lt; #{statement.res.body}
+					- unless statement.res.stamp.nil?
+						%img{:src => "#{image_size_change(statement.res.stamp,16,true)}", :alt => "#{statement.res.stamp}", :title => "#{statement.res.stamp}"}
 
 		/ 発言本文
 		- unless statement.body.nil?


### PR DESCRIPTION
- ポップアップした画像から画像にリンクを張ることで、「リンクを新しいタブで表示」で画像のみ表示をできるようにした。
- レス先がスタンプ投稿の場合、元発言表示に小さなスタンプを表示するようにした。