### PR TITLE
スタンプ機能の強化

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
     domain_name (0.5.20160310)
       unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.10)
-    execjs (2.6.0)
+    execjs (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fuubar (2.0.0)
@@ -249,5 +249,8 @@ DEPENDENCIES
   uglifier
   yui-compressor
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.11.2
+   1.12.4

--- a/assets/js/massr.js
+++ b/assets/js/massr.js
@@ -783,7 +783,7 @@ $(function(){
 		$('.item-stamp').on('click', function(){
 			var statement_id = $(this).parent().parent().parent().parent().attr('id');
 			posting = true;
-			var body = "stamp=" + $(this).attr('src');
+			var body = "stamp=" + $(this).attr('src') + "&stamp_id=" + $(this).attr('id');
 			if (statement_id){
 				body = body + "&res_id=" + statement_id;
 			}

--- a/assets/js/massr.js
+++ b/assets/js/massr.js
@@ -907,7 +907,7 @@ $(function(){
 		var str = $(this).val();
 		$('img.item-stamp').each(function(i, elm){
 			var tag = $(elm).data('stamp-tag') || '';
-			if (tag.indexOf(str) > -1) {
+			if (tag.toLowerCase().indexOf(str.toLowerCase()) > -1) {
 				$(elm).parent().parent().parent().show();
 			} else {
 				$(elm).parent().parent().parent().hide();

--- a/assets/js/massr.js
+++ b/assets/js/massr.js
@@ -762,6 +762,9 @@ $(function(){
 	};
 	$('.popup-image').mfp();
 	$('a.stamp-button').mfp();
+	$('a.stamp-button').on('click', function(){
+		setTimeout(function(){$('#search-tag-field').focus();},400);
+	});
 
 	$.fn.image_size_change = function(url,size,centering){
 		var uri = document.createElement('a');

--- a/assets/js/massr.js
+++ b/assets/js/massr.js
@@ -90,7 +90,7 @@ $(function(){
 
 	/*
 	 * setup auto reloading
-	 *   reloading each 30sec without focused in TEXTAREA
+	 *	 reloading each 30sec without focused in TEXTAREA
 	 */
 	var retry_count_of_reload = 0;
 	var reload_interval_time = 30000;
@@ -587,8 +587,8 @@ $(function(){
 	/*
 	 * stamp
 	 */
-	var USE     = 0;
-	var UNUSE   = 1;
+	var USE		= 0;
+	var UNUSE	= 1;
 	function toggleStamp(target , statement_id , image_url, stat){
 		image_url = $.fn.image_size_change(image_url,1);
 
@@ -633,13 +633,26 @@ $(function(){
 			if (container.attr('id') && src) {
 				toggleStamp($(this), container.attr('id'), src, UNUSE);
 			}
+			return false;}).
+		on('click', 'button#update-stamp-tag', function(){
+			var e = $('#stamp-tag');
+			$.ajax({
+				url: '/stamp/tag',
+				type: 'POST',
+				data: "stamp_id=" + e.data('stamp-id') + "&tag=" + e.val()}).
+			done(function(result){
+					message.success(_['success_update_stamp_tag']);
+				}).
+			fail(function(XMLHttpRequest, textStatus, errorThrown){
+					message.error('(' + textStatus + ')');
+				});
 			return false;});
 
 	/*
 	 * admin
 	 */
-	var ADMIN        = 0;
-	var AUTHORIZED   = 1;
+	var ADMIN		 = 0;
+	var AUTHORIZED	 = 1;
 	var UNAUTHORIZED = 9;
 
 	function toggleStatus(massr_id, stat, on, off){
@@ -799,6 +812,7 @@ $(function(){
 			});
 			$.magnificPopup.close();
 		});
+
 	});
 
 	/*
@@ -884,6 +898,18 @@ $(function(){
 			}
 		});
 		return false;
+	});
+
+	$('#search-tag-field').on('keyup', function(){
+		var str = $(this).val();
+		$('img.item-stamp').each(function(i, elm){
+			var tag = $(elm).data('stamp-tag') || '';
+			if (tag.indexOf(str) > -1) {
+				$(elm).parent().parent().parent().show();
+			} else {
+				$(elm).parent().parent().parent().hide();
+			}
+		});
 	});
 
 	if (fileEnabled) {

--- a/helpers/init.rb
+++ b/helpers/init.rb
@@ -39,7 +39,7 @@ module Massr
 					begin
 						Mail.deliver do
 							from 'no-reply@tdtds.jp'
-							to  user.email
+							to	user.email
 							subject 'Message from Massr'
 							content_type 'text/plain; charset=UTF-8'
 							body msg.gsub(/^\t+/, '')
@@ -92,6 +92,17 @@ module Massr
 
 			def stamps
 				cache.get('stamp')
+			end
+
+			def photo_to_stamp(photo)
+				stamps.find{|stamp| 
+					org = image_size_change(stamp.image_url,
+								SETTINGS['setting']['stamp_thumbnail_size'],true)
+					dst = image_size_change(photo,
+								SETTINGS['setting']['stamp_thumbnail_size'],true)
+
+					org == dst
+				}
 			end
 
 			def clear_search_cache(body)

--- a/helpers/init.rb
+++ b/helpers/init.rb
@@ -90,7 +90,7 @@ module Massr
 				end
 			end
 
-			def stamp_urls
+			def stamps
 				cache.get('stamp')
 			end
 

--- a/models/stamp.rb
+++ b/models/stamp.rb
@@ -9,6 +9,7 @@ module Massr
 
 		key :image_url,  :type => String, :required => true , :unique => true
 		key :post_cnt,	 :type => Integer, :default => 0
+		key :tag,		 :type => String
 
 		timestamps!
 
@@ -52,7 +53,14 @@ module Massr
 		end
 
 		def post_stamp()
-			self.increment({:post_cnt => 1})
+			self[:post_cnt] += 1
+			if save
+				return self
+			end
+		end
+
+		def update_tag(request)
+			self[:tag] = request[:tag]
 			if save
 				return self
 			end
@@ -64,6 +72,7 @@ module Massr
 				'id' => id,
 				'created_at' => created_at.localtime.strftime('%Y-%m-%d %H:%M:%S'),
 				'image_url' => image_url,
+				'tag' => tag,
 				'post_cnt' => post_cnt,
 				'original' => original ? original.to_hash : nil
 			}

--- a/models/stamp.rb
+++ b/models/stamp.rb
@@ -8,6 +8,7 @@ module Massr
 		include MongoMapper::Document
 
 		key :image_url,  :type => String, :required => true , :unique => true
+		key :post_cnt,	 :type => Integer, :default => 0
 
 		timestamps!
 
@@ -16,24 +17,12 @@ module Massr
 		validates_uniqueness_of :image_url
 
 		def self.get_stamps(options={})
-			options[:order]         = :created_at.desc
+			options[:order]			= :post_cnt.desc
 			return self.all(options)
 		end
 
-		def self.get_image_urls(options={})
-			options[:order]         = :created_at.desc
-			[].tap{ |a|
-				json = self.all.to_json(:only => [:image_url])
-				JSON.parse(json).each do |data|
-					data.each do |k,v|
-						a << v
-					end
-				end
-			}
-		end
-
 		def self.get_statements(options={})
-			options[:order]         = :created_at.desc
+			options[:order]			= :created_at.desc
 			stamps = self.all(options)
 
 			statements = Array.new
@@ -62,12 +51,20 @@ module Massr
 			end
 		end
 
+		def post_stamp()
+			self.increment({:post_cnt => 1})
+			if save
+				return self
+			end
+		end
+
 		def to_hash
 			original = Statement.find_by_id(original_id)
 			{
 				'id' => id,
 				'created_at' => created_at.localtime.strftime('%Y-%m-%d %H:%M:%S'),
 				'image_url' => image_url,
+				'post_cnt' => post_cnt,
 				'original' => original ? original.to_hash : nil
 			}
 		end

--- a/models/stamp.rb
+++ b/models/stamp.rb
@@ -8,7 +8,7 @@ module Massr
 		include MongoMapper::Document
 
 		key :image_url,  :type => String, :required => true , :unique => true
-		key :post_cnt,	 :type => Integer, :default => 0
+		key :popular,	 :type => Integer, :default => 0
 		key :tag,		 :type => String
 
 		timestamps!
@@ -18,7 +18,7 @@ module Massr
 		validates_uniqueness_of :image_url
 
 		def self.get_stamps(options={})
-			options[:order]			= :post_cnt.desc
+			options[:order]			= :popular.desc
 			return self.all(options)
 		end
 
@@ -53,7 +53,7 @@ module Massr
 		end
 
 		def post_stamp()
-			self[:post_cnt] += 1
+			self[:popular] += 1
 			if save
 				return self
 			end
@@ -73,7 +73,7 @@ module Massr
 				'created_at' => created_at.localtime.strftime('%Y-%m-%d %H:%M:%S'),
 				'image_url' => image_url,
 				'tag' => tag,
-				'post_cnt' => post_cnt,
+				'popular' => popular,
 				'original' => original ? original.to_hash : nil
 			}
 		end

--- a/public/default.json
+++ b/public/default.json
@@ -69,6 +69,7 @@
 		"success_use_stamp": "スタンプに登録しました",
 		"success_unuse_stamp": "スタンプから削除しました",
 		"success_delete_user": "を削除しました",
-		"fail_change_status": "ステータス変更に失敗しました"
+		"fail_change_status": "ステータス変更に失敗しました",
+		"success_update_stamp_tag": "スタンプのタグを更新しました"
 	}
 }

--- a/routes/init.rb
+++ b/routes/init.rb
@@ -12,7 +12,7 @@ module Massr
 	class App < Sinatra::Base
 		before do
 			cache.delete('main') unless request.get?
-			cache.set('stamp', Stamp.get_image_urls) unless cache.get('stamp')
+			cache.set('stamp', Stamp.get_stamps {|i| i.to_hash}) unless cache.get('stamp')
 
 			case request.path
 			when '/unauthorized'
@@ -25,7 +25,7 @@ module Massr
 				unless session[:user_id]
 					redirect '/login'
 				else
-					user =  User.find_by_id(session[:user_id])
+					user =	User.find_by_id(session[:user_id])
 					redirect '/logout' unless user
 					redirect '/logout' if user.twitter_user_id == nil && user.twitter_id != session[:twitter_id]
 					redirect '/logout' unless session[:twitter_icon_url_https]

--- a/routes/stamp.rb
+++ b/routes/stamp.rb
@@ -30,9 +30,17 @@ module Massr
 
 		get '/stamps' do
 			haml :user_photos, :locals => {
-				:statements => Stamp.get_statements(),
+				:statements => cache.get('stamp').map {|s| s.original},
 				:q => nil,
 				:pagenation => false}
+		end
+
+		post '/stamp/tag' do
+			@stamp = Stamp.find_by_id(request[:stamp_id])
+			@stamp.update_tag( request ) unless @stamp.nil?
+			cache.delete('stamp')
+			cache.set('stamp', Stamp.get_stamps {|i| i.to_hash})
+			@stamp.to_hash.to_json
 		end
 	end
 end

--- a/routes/stamp.rb
+++ b/routes/stamp.rb
@@ -25,7 +25,7 @@ module Massr
 		end
 
 		after '/stamp' do
-			cache.set('stamp', Stamp.get_image_urls) unless request.get?
+			cache.set('stamp', Stamp.get_stamps {|i| i.to_hash}) unless request.get?
 		end
 
 		get '/stamps' do

--- a/routes/statement.rb
+++ b/routes/statement.rb
@@ -24,6 +24,10 @@ module Massr
 				@statement.update_statement( request ) unless request[:body].size == 0
 			else
 				@statement.update_statement( request ) unless request[:stamp].size == 0
+				stamp = Stamp.find_by_id(request[:stamp_id])
+				stamp.post_stamp() unless stamp.nil?
+				cache.delete('stamp')
+				cache.set('stamp', Stamp.get_stamps {|i| i.to_hash})
 			end
 			if @statement.res && @statement.res.user.email.length > 0 && @statement.res.user.massr_id != request[:user].massr_id
 				send_mail(@statement.res.user, @statement)

--- a/views/header.haml
+++ b/views/header.haml
@@ -2,11 +2,11 @@
 	- if current_user
 		.mfp-hide{:id => "stamps"}
 			.items
-				- stamp_urls.each do |url|
+				- stamps.each do |stamp|
 					.submit-stamp
 						.stamp-style
 							.stamp
-								%img.item-stamp{:src => "#{image_size_change(url,SETTINGS['setting']['stamp_thumbnail_size'],true)}"}
+								%img.item-stamp{:src => "#{image_size_change(stamp.image_url,SETTINGS['setting']['stamp_thumbnail_size'],true)}", :id => stamp.id, :title => stamp.post_cnt}
 	.navbar.navbar-static-top
 		.navbar-inner
 			.container

--- a/views/header.haml
+++ b/views/header.haml
@@ -1,12 +1,13 @@
 %header
 	- if current_user
 		.mfp-hide{:id => "stamps"}
+			%input.search-query{:id => "search-tag-field", :type => "text", :name => "q", :placeholder => _search}
 			.items
 				- stamps.each do |stamp|
 					.submit-stamp
 						.stamp-style
 							.stamp
-								%img.item-stamp{:src => "#{image_size_change(stamp.image_url,SETTINGS['setting']['stamp_thumbnail_size'],true)}", :id => stamp.id, :title => stamp.post_cnt}
+								%img.item-stamp{:src => "#{image_size_change(stamp.image_url,SETTINGS['setting']['stamp_thumbnail_size'],true)}", :id => stamp.id, :title => "#{stamp.tag} #{stamp.post_cnt}", :"data-stamp-tag" => stamp.tag}
 	.navbar.navbar-static-top
 		.navbar-inner
 			.container

--- a/views/header.haml
+++ b/views/header.haml
@@ -7,7 +7,7 @@
 					.submit-stamp
 						.stamp-style
 							.stamp
-								%img.item-stamp{:src => "#{image_size_change(stamp.image_url,SETTINGS['setting']['stamp_thumbnail_size'],true)}", :id => stamp.id, :title => "#{stamp.tag} #{stamp.post_cnt}", :"data-stamp-tag" => stamp.tag}
+								%img.item-stamp{:src => "#{image_size_change(stamp.image_url,SETTINGS['setting']['stamp_thumbnail_size'],true)}", :id => stamp.id, :title => "#{stamp.tag} #{stamp.popular}", :"data-stamp-tag" => stamp.tag}
 	.navbar.navbar-static-top
 		.navbar-inner
 			.container

--- a/views/popup_photo.haml
+++ b/views/popup_photo.haml
@@ -1,6 +1,6 @@
 .mfp-hide.popup-photo{:id => "#{statement._id}"}
 	.stamp
-		- if stamp_urls.map{|url| image_size_change(url,SETTINGS['setting']['stamp_thumbnail_size'],true)}.include? image_size_change(photo,SETTINGS['setting']['stamp_thumbnail_size'],true)
+		- if stamps.map{|stamp| image_size_change(stamp.image_url,SETTINGS['setting']['stamp_thumbnail_size'],true)}.include? image_size_change(photo,SETTINGS['setting']['stamp_thumbnail_size'],true)
 			%a.unusestamp
 				%i.icon-remove-circle{:title => _unuse_stamp}
 		- else

--- a/views/popup_photo.haml
+++ b/views/popup_photo.haml
@@ -1,6 +1,6 @@
 .mfp-hide.popup-photo{:id => "#{statement._id}"}
 	.stamp
-		- if stamps.map{|stamp| image_size_change(stamp.image_url,SETTINGS['setting']['stamp_thumbnail_size'],true)}.include? image_size_change(photo,SETTINGS['setting']['stamp_thumbnail_size'],true)
+		- if photo_to_stamp(photo)
 			%a.unusestamp
 				%i.icon-remove-circle{:title => _unuse_stamp}
 		- else
@@ -9,6 +9,11 @@
 	.image
 		%a{:href => "#{photo}", :target => "_blank"}
 			%img{:src => "#{photo}" , :alt => "#{statement._id}" , :title => "#{statement._id}"}
+	- if stamp = photo_to_stamp(photo)
+		.tag{:style => "width: fit-content"}
+			%span Tag:
+			%input#stamp-tag{:type => "text", :value => "#{stamp.tag}", :"data-stamp-id" => stamp.id}
+			%button#update-stamp-tag{:class => "btn btn-small submit"} 更新
 	- if detail
 		.statement{:id => "st-#{statement._id}"}
 			/ アイコン


### PR DESCRIPTION
スタンプの数が増えてきたので管理する機能を実装しました。

- スタンプにPOST回数とタグを保存できるようにした
- スタンプの表示順をPOST回数の降順に
- スタンプ選択時にタグの部分一致で絞り込めるようにした
- スタンプ元のポップアップ時にタグを編集可能に
- スタンプ一覧をキャッシュから取得して高速化
