### PR TITLE
Googleへの投稿画像に対するサイズ調整機能においてセンタリングオプション付与パターンの考慮漏れを修正

### DIFF
--- a/assets/js/massr.js
+++ b/assets/js/massr.js
@@ -783,7 +783,11 @@ $(function(){
 			} else {
 				var parts = url.split("/");
 				var last = parts.pop();
-				parts.push('s'+size);
+				if (centering == true){
+					parts.push('s' + size + '-c');
+				} else {
+					parts.push('s' + size);
+				}
 				parts.push(last);
 				return parts.join('/')
 			}

--- a/helpers/init.rb
+++ b/helpers/init.rb
@@ -77,13 +77,17 @@ module Massr
 				if (uri.host =~ /\A[0-9a-zA-Z]+\.googleusercontent\.com\z/)
 					pattern = /\/([whs][0-9]+|r(90|180|270)|-|c|p|o|d)+\//
 					if url =~ pattern
-						if centering 
+						if centering
 							url.sub(pattern , "/s#{size}-c/")
 						else
 							url.sub(pattern , "/s#{size}/")
 						end
 					else
-						url.split('/').insert(-2,"s#{size}").join('/')
+						if centering
+							url.split('/').insert(-2,"s#{size}-c").join('/')
+						else
+							url.split('/').insert(-2,"s#{size}").join('/')
+						end
 					end
 				else
 					url
@@ -95,7 +99,7 @@ module Massr
 			end
 
 			def photo_to_stamp(photo)
-				stamps.find{|stamp| 
+				stamps.find{|stamp|
 					org = image_size_change(stamp.image_url,
 								SETTINGS['setting']['stamp_thumbnail_size'],true)
 					dst = image_size_change(photo,


### PR DESCRIPTION
スタンプの状態（登録の可否状態）が正しく制御できていなかった問題に対する修正です。

Googleに投稿された画像のサイズ調整用パラメータの付与にセンタリングに対する考慮が漏れていたため、スタンプの一致判定（元画像とスタンプ画像）に齟齬が出ていました。