### PR TITLE
自分の最新の投稿がすぐに出てこないの、これのせいでは?

### DIFF
--- a/helpers/init.rb
+++ b/helpers/init.rb
@@ -55,7 +55,7 @@ module Massr
 			end
 
 			def param_date
-				date = params[:date] ? params[:date] : (Time.now + 1).strftime("%Y%m%d%H%M%S")
+				date = params[:date] ? params[:date] : (Time.now + 10).strftime("%Y%m%d%H%M%S")
 			end
 
 			def get_icon_url(user)


### PR DESCRIPTION
投稿の保存に1秒以上かかったら検索対象にならないような。

(Mongoid移植ブランチへ適用済みなので、このプルリクをマージする必要はありません)