### PR TITLE
Fix/stamp via Gyazo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'uglifier'
 gem 'yui-compressor'
 
 gem 'puma'
-gem 'haml', require: 'haml'
+gem 'hamlit', require: 'hamlit'
 gem 'omniauth', require: 'omniauth'
 gem 'omniauth-twitter', require: 'omniauth-twitter'
 gem 'mongo_mapper', require: 'mongo_mapper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,8 +58,9 @@ GEM
       httmultiparty
       httparty
       json
-    haml (5.0.1)
+    hamlit (2.8.4)
       temple (>= 0.8.0)
+      thor
       tilt
     hashie (3.5.5)
     hike (1.2.3)
@@ -201,6 +202,7 @@ GEM
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
+    thor (0.19.4)
     thread_safe (0.3.6)
     tilt (1.4.1)
     timers (4.1.2)
@@ -235,7 +237,7 @@ DEPENDENCIES
   dalli
   fuubar
   gyazo
-  haml
+  hamlit
   mail
   mongo_mapper
   newrelic_rpm

--- a/assets/js/massr.js
+++ b/assets/js/massr.js
@@ -773,9 +773,7 @@ $(function(){
 		var uri = document.createElement('a');
 		uri.href = url;
 
-		var pattern = /^[0-9a-zA-Z]+\.googleusercontent\.com$/;
-
-		if (uri.hostname.match(pattern) != null){
+		if(uri.hostname.match(/^[0-9a-zA-Z]+\.googleusercontent\.com$/) != null) {
 			pattern = /\/([whs][0-9]+|r(90|180|270)|-|c|p|o|d)+\//;
 			if (url.match(pattern) != null ){
 				if (centering == true){
@@ -794,6 +792,8 @@ $(function(){
 				parts.push(last);
 				return parts.join('/')
 			}
+		} else if(uri.hostname.match(/^thumb\.gyazo\.com$/) != null) {
+			return url.replace(/\/thumb\/\d+/, '/thumb/' + size)
 		} else {
 			return url;
 		}

--- a/massr.rb
+++ b/massr.rb
@@ -23,7 +23,7 @@ module Massr
 	end
 
 	class App < Sinatra::Base
-		set :haml, { format: :html5, escape_html: true }
+		set :haml, {format: :html5}
 
 		set :assets_precompile, %w(application.js application.css *.png *.jpg *.svg)
 		set :assets_css_compressor, :yui


### PR DESCRIPTION
Gyazoプラグイン経由で投稿した画像をスタンプ化できない。

原因は以下のとおり:

* stamp modelには画像のURLをサイズ「1」で正規化したものが入っている
* 正規化はクライアントサイドのjs内で行われている
* サーバサイドではなにもチェックしていない

という状況下で、サイズ変更メソッドがサーバサイドしかGyazoに対応していなかったため、クライアントサイドではURLの正規化が行われておらず、もとのサイズのままのURLがmodelに保存されていた。このためサイズ「1」を前提にしたスタンプの検索が機能せず、登録しても見つからないという状況になっていた。

この修正ではサーバサイドのみで実装されていたGyazoのサイズ変更メソッド(image_size_change)を、クライアントサイドでも実装することで問題を回避した。ただし、すでにスタンプ化された(が検索されない)画像はそのままDBに残る。いずれ掃除が必要。

また、modelに登録するURLに暗黙の正規化が求められていて、その責務が呼び出し元にあるのは好ましくないので、根本的に実装を変えるべきである。