### PR TITLE
enable logging

### DIFF
--- a/massr.rb
+++ b/massr.rb
@@ -46,6 +46,7 @@ module Massr
 				}
 			end
 
+			enable :logging
 			Massr::Plugin::Logging.instance.level(Massr::Plugin::Logging::WARN)
 		end
 
@@ -72,6 +73,7 @@ module Massr
 				}
 			end
 
+			enable :logging
 			Massr::Plugin::Logging.instance.level(Massr::Plugin::Logging::DEBUG)
 		end
 


### PR DESCRIPTION
なんと、ログ出力が有効になっていなかったw なぜかHerokuでは問題なく出ていたので気付かず。