### PR TITLE
Safari 11.1 で発生した、POSTデータに空のデータが入るとデータが送信されない問題への修正

### DIFF
--- a/assets/js/massr.js
+++ b/assets/js/massr.js
@@ -153,6 +153,12 @@ $(function(){
 		if($body.val().trim()){
 			var method = $form.attr('method');
 			var formdata = new FormData(form);
+
+			// for Safari
+			if(formdata.get("photo").name == "") {
+				formdata.remove("photo");
+			}
+
 			$form.find("button").attr("disabled", "disabled").empty().append('<img src="/img/masao_loading.gif">');
 			$form.find("textarea").attr("disabled", "disabled");
 


### PR DESCRIPTION
Safari 11.1 で発生している画像なし投稿ができない問題に対処しました。

POST 電文に空のファイル指定があるのが問題のようだったので、
送信前に空であった場合に除去する処理を加えました。