### PR TITLE
force using https in twitter icon

### DIFF
--- a/assets/js/massr.js
+++ b/assets/js/massr.js
@@ -14,16 +14,8 @@ Massr = {
 	me: '',
 	settings: {},
 
-	isHttps: function(){
-		return location.href.match(/^https/);
-	},
-
 	get_icon_url: function(user){
-		if (this.isHttps()) {
-			return user.twitter_icon_url_https;
-		} else {
-			return user.twitter_icon_url;
-		}
+		return user.twitter_icon_url_https;
 	},
 
 	shrinkText: function(text){ // replace CR/LF to single space

--- a/helpers/init.rb
+++ b/helpers/init.rb
@@ -59,7 +59,7 @@ module Massr
 			end
 
 			def get_icon_url(user)
-				request.scheme == 'https' ? user['twitter_icon_url_https'] : user['twitter_icon_url']
+				user['twitter_icon_url_https']
 			end
 
 			def icon_dir


### PR DESCRIPTION
http上で動いていてもTwitterアイコンは常にhttps版を使う