### PR TITLE
fix js error on post when media plugin not specified

### DIFF
--- a/assets/js/massr.js
+++ b/assets/js/massr.js
@@ -147,7 +147,7 @@ $(function(){
 			var formdata = new FormData(form);
 
 			// for Safari
-			if(formdata.get("photo").name == "") {
+			if(formdata.get("photo") && formdata.get("photo").name == "") {
 				formdata.delete("photo");
 			}
 
@@ -205,7 +205,7 @@ $(function(){
 			var formdata = new FormData(form);
 
 			// for Safari
-			if(formdata.get("photo").name == "") {
+			if(formdata.get("photo") && formdata.get("photo").name == "") {
 				formdata.delete("photo");
 			}
 


### PR DESCRIPTION
mediaプラグインを指定していないとき、投稿フォームにphoto要素がなくなるので投稿時にエラーになるのを修正