### PR TITLE
Redirect on https

### DIFF
--- a/assets/js/massr.js
+++ b/assets/js/massr.js
@@ -505,8 +505,8 @@ $(function(){
 				$.ajax({
 					url: '/statement/'+statement,
 					type: 'DELETE'}).
-				done(function(result) {
-					location.href = "/";
+				always(function() {
+					location.reload();
 				});
 			}
 		}

--- a/routes/admin.rb
+++ b/routes/admin.rb
@@ -12,7 +12,7 @@ module Massr
 	class App < Sinatra::Base
 		before '/admin*' do
 			user =  User.find_by(id: session[:user_id])
-			redirect '/' unless user.admin?
+			redirect to('/') unless user.admin?
 		end
 		
 		get '/admin' do

--- a/routes/auth.rb
+++ b/routes/auth.rb
@@ -16,7 +16,7 @@ module Massr
 
 		get '/logout' do
 			session.clear
-			redirect '/'
+			redirect to('/')
 		end
 
 		get '/auth/twitter/callback' do
@@ -36,9 +36,9 @@ module Massr
 				User.find_by(twitter_id: session[:twitter_id]))
 			if user
 				session[:user_id] = user._id
-				redirect '/'
+				redirect to('/')
 			else
-				redirect '/user'
+				redirect to('/user')
 			end
 		end
 

--- a/routes/init.rb
+++ b/routes/init.rb
@@ -20,18 +20,18 @@ module Massr
 			when '/logout'
 			when %r|^/auth/|
 			when '/user'
-				redirect '/login' unless session[:twitter_user_id]
+				redirect to('/login') unless session[:twitter_user_id]
 			else
 				unless session[:user_id]
-					redirect '/login'
+					redirect to('/login')
 				else
 					user =	User.find_by(id: session[:user_id])
-					redirect '/logout' unless user
-					redirect '/logout' if user.twitter_user_id == nil && user.twitter_id != session[:twitter_id]
-					redirect '/logout' unless session[:twitter_icon_url_https]
-					redirect '/user?update=true' unless user.twitter_user_id
-					redirect '/user?update=true' unless user.twitter_icon_url_https
-					redirect '/unauthorized' unless user.authorized?
+					redirect to('/logout') unless user
+					redirect to('/logout') if user.twitter_user_id == nil && user.twitter_id != session[:twitter_id]
+					redirect to('/logout') unless session[:twitter_icon_url_https]
+					redirect to('/user?update=true') unless user.twitter_user_id
+					redirect to('/user?update=true') unless user.twitter_icon_url_https
+					redirect to('/unauthorized') unless user.authorized?
 				end
 			end
 		end

--- a/routes/search.rb
+++ b/routes/search.rb
@@ -11,7 +11,7 @@ module Massr
 	class App < Sinatra::Base
 		before '/search*' do
 			@q = params[:q].strip if params[:q]
-			redirect '/' unless @q
+			redirect to('/') unless @q
 		end
 
 		get '/search.json' do
@@ -24,12 +24,12 @@ module Massr
 
 		get '/search' do
 			if @q.size == 0 then
-				redirect '/'
+				redirect to('/')
 				return
 			end
 
 			if @q != params[:q] then
-				redirect '/search?q=' + @q
+				redirect to('/search?q=' + @q)
 				return
 			end
 
@@ -49,7 +49,7 @@ module Massr
 					:statements => statements ,
 					:q => @q}
 			rescue RegexpError
-				redirect '/'
+				redirect to('/')
 			end
 		end
 

--- a/routes/stamp.rb
+++ b/routes/stamp.rb
@@ -21,7 +21,7 @@ module Massr
 
 		delete '/stamp' do
 			Stamp.delete_stamp(params[:image_url])
-			redirect '/'
+			redirect to('/')
 		end
 
 		after '/stamp' do

--- a/routes/statement.rb
+++ b/routes/statement.rb
@@ -36,7 +36,7 @@ module Massr
 			if params[:format] == 'json'
 				@statement.to_hash.to_json
 			else
-				redirect '/'
+				redirect to('/')
 			end
 		end
 
@@ -86,7 +86,7 @@ module Massr
 				stamp.destroy if stamp
 				Statement.find_by(_id: params[:id]).delete
 			end
-			redirect '/'
+			redirect to('/')
 		end
 
 		before '/statement/:id/like' do

--- a/routes/user.rb
+++ b/routes/user.rb
@@ -44,10 +44,10 @@ module Massr
 
 		delete '/user/:massr_id' do
 			user =  User.find_by(id: session[:user_id])
-			redirect '/' unless user.admin?
+			redirect to('/') unless user.admin?
 			Statement.delete_all_statements(@user)
 			@user.destroy
-			redirect '/'
+			redirect to('/')
 		end
 
 		before '/user/:massr_id/photos*' do
@@ -178,12 +178,12 @@ module Massr
 				session[:user_id] = user._id
 			end
 
-			redirect '/'
+			redirect to('/')
 		end
 
 		put '/user/:massr_id' do
 			user =  User.find_by(id: session[:user_id])
-			redirect '/' unless user.admin?
+			redirect to('/') unless user.admin?
 			User.change_status(params[:massr_id],params[:status])
 		end
 	end


### PR DESCRIPTION
httpsのreverse proxyの後ろで動かしている場合に、statement delete後にエラーになってreloadが発生しないのを抑制する。SinatraのredirectがhttpなURLを返すのをブラウザが止めるのが原因。とりあえずサーバからのredirect指示は無視して、ブラウザ側で強制的にreloadすることにした。